### PR TITLE
Backport cfa1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,19 @@
--------------------------------------------------------------------------
+-------------------------------------------------------------------
+Thu Jul 18 10:40:32 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
+
+- BACKPORT: Dropped the changes_only argument of
+  Default,DeviceMap#save following the same change in
+  BaseModel#save in cfa-1.0.0
+  because the merging was not working anyway (bsc#1137948)
+- 0.6.6
+
+-------------------------------------------------------------------
 Thu Nov 30 14:35:47 UTC 2017 - jreidinger@suse.com
 
 - fix reading GRUB_TERMINAL (caused by fix for bsc#1068578)
 - 0.6.5
 
--------------------------------------------------------------
+-------------------------------------------------------------------
 Thu Nov 30 07:45:45 UTC 2017 - jreidinger@suse.com
 
 - avoid crash if config file uses trailing comment (bsc#1068578)

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 # 0.5.X contain new minimal changes, that needs modification
-gem "cfa", "~> 0.5"
+gem "cfa", "~> 1.0"
 
 group :development, :test do
   gem "coveralls"
@@ -10,4 +10,5 @@ end
 
 group :development do
   gem "rubocop"
+  gem "rake"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ group :development, :test do
 end
 
 group :development do
-  gem "rubocop"
+  gem "rubocop", "0.41.2"
   gem "rake"
 end

--- a/cfa_grub2.gemspec
+++ b/cfa_grub2.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "cfa_grub2"
-  s.version     = "0.6.5"
+  s.version     = "0.6.6"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Josef Reidinger"]
   s.email       = ["jreidinger@suse.cz"]
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "cfa", "~> 0.5"
+  s.add_dependency "cfa", "~> 1.0"
 
   s.files        = Dir["{lib}/**/*.rb"]
   s.require_path = "lib"

--- a/lib/cfa/grub2/default.rb
+++ b/lib/cfa/grub2/default.rb
@@ -31,7 +31,7 @@ module CFA
           file_handler: file_handler)
       end
 
-      def save(changes_only: false)
+      def save
         # serialize kernel params object before save
         kernels = [@kernel_params, @xen_hypervisor_params, @xen_kernel_params,
                    @recovery_params]

--- a/lib/cfa/grub2/device_map.rb
+++ b/lib/cfa/grub2/device_map.rb
@@ -23,7 +23,7 @@ module CFA
           file_handler: file_handler)
       end
 
-      def save(changes_only: false)
+      def save
         raise "Too many grub devices. Limit is 8." if grub_devices.size > 8
 
         super

--- a/spec/grub2_default_spec.rb
+++ b/spec/grub2_default_spec.rb
@@ -187,8 +187,7 @@ describe CFA::Grub2::Default do
         config.generic_set("GRUB_ENABLE_CRYPTODISK", "true")
         config.save
 
-        # TODO: check why augeas sometimes espace and sometimes not
-        expect(memory_file.content).to eq("GRUB_ENABLE_CRYPTODISK=\"true\"\n")
+        expect(memory_file.content.strip).to eq("GRUB_ENABLE_CRYPTODISK=\"true\"")
       end
     end
   end

--- a/spec/grub2_default_spec.rb
+++ b/spec/grub2_default_spec.rb
@@ -187,7 +187,8 @@ describe CFA::Grub2::Default do
         config.generic_set("GRUB_ENABLE_CRYPTODISK", "true")
         config.save
 
-        expect(memory_file.content.strip).to eq("GRUB_ENABLE_CRYPTODISK=\"true\"")
+        expect(memory_file.content.strip)
+          .to eq("GRUB_ENABLE_CRYPTODISK=\"true\"")
       end
     end
   end


### PR DESCRIPTION
SLE12 SP5 gets new cfa because of set of bug fixes including L3 fixes. This cause grub2_cfa failing there as can be seen at https://build.suse.de/package/view_file/home:repo-checker/reports/SUSE:SLE-12-SP5:GA:Staging:A

Backport aim to be minimal, so no rubocop changes done.