### PR TITLE
handle GRUB_SAVEDEFAULT config option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Tue 02 Jun 2020 07:39:40 PM UTC - ammiera@hotmail.com
+
+- Added support for GRUB_SAVEDEFAULT
+- 2.1.0
+
 -------------------------------------------------------------------
 Thu Jun 20 13:10:26 UTC 2019 - Martin Vidner <mvidner@suse.com>
 

--- a/cfa_grub2.gemspec
+++ b/cfa_grub2.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "cfa_grub2"
-  s.version     = "2.0.0"
+  s.version     = "2.1.0"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Josef Reidinger"]
   s.email       = ["jreidinger@suse.cz"]

--- a/lib/cfa/grub2/default.rb
+++ b/lib/cfa/grub2/default.rb
@@ -99,6 +99,13 @@ module CFA
         )
       end
 
+      def savedefault
+        @savedefault ||= BooleanValue.new(
+          "GRUB_SAVEDEFAULT", self,
+          true_value: "true", false_value: "false"
+        )
+      end
+
       def cryptodisk
         @cryptodisk ||= BooleanValue.new("GRUB_ENABLE_CRYPTODISK", self,
           true_value: "y", false_value: "n")

--- a/spec/grub2_default_spec.rb
+++ b/spec/grub2_default_spec.rb
@@ -170,6 +170,21 @@ describe CFA::Grub2::Default do
     end
   end
 
+  describe "#savedefault" do
+    let(:file_content) { "GRUB_SAVEDEFAULT=false\n" }
+
+    it "returns object representing boolean state" do
+      expect(config.savedefault).to be_a(boolean_value_class)
+      # few simple test to verify params
+      expect(config.savedefault.enabled?).to eq(false)
+
+      # and store test
+      config.savedefault.enable
+      config.save
+      expect(memory_file.content).to eq("GRUB_SAVEDEFAULT=true\n")
+    end
+  end
+
   describe "#kernel_params" do
     let(:file_content) do
       "GRUB_CMDLINE_LINUX_DEFAULT=\"quite console=S0 console=S1 vga=0x400\" " \


### PR DESCRIPTION
As the commit message states. I am currently working on adding "savedefault" option which I use on my dual boot machines to YaST, and it has turned out that the API lacks it, hence my change.